### PR TITLE
Allow for metrics with invalid/incorrect "value"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+elixir 1.11.1-otp-23
+erlang ref:4a42e03c796ee23c6f8ce479722653ad82c10a8e
+nodejs 12.13.0
+python 3.8.1

--- a/lib/open_rtb_ecto/v2/bid_request/metric.ex
+++ b/lib/open_rtb_ecto/v2/bid_request/metric.ex
@@ -21,6 +21,5 @@ defmodule OpenRtbEcto.V2.BidRequest.Metric do
   def changeset(metric, attrs \\ %{}) do
     metric
     |> cast(attrs, [:type, :value, :vendor, :ext])
-    |> validate_number(:value, greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0)
   end
 end


### PR DESCRIPTION
Current validation follows the 2.5 spec. High percentage of production traffic observed with invalid `metric.value`