### PR TITLE
Video.api list can contain any positive integer

### DIFF
--- a/lib/open_rtb_ecto/v2/bid_request/video.ex
+++ b/lib/open_rtb_ecto/v2/bid_request/video.ex
@@ -93,7 +93,21 @@ defmodule OpenRtbEcto.V2.BidRequest.Video do
     |> validate_subset(:playbackmethod, 1..6)
     |> validate_inclusion(:playbackend, 1..3)
     |> validate_subset(:delivery, 1..3)
-    |> validate_subset(:api, 1..6)
+    |> validate_list_of_pos_ints(:api)
     |> validate_subset(:companiontype, 1..3)
+  end
+
+  defp validate_list_of_pos_ints(changeset, field) do
+    case get_change(changeset, field) do
+      nil ->
+        changeset
+
+      values ->
+        if Enum.all?(values, fn v -> is_integer(v) and v > 0 end) do
+          changeset
+        else
+          add_error(changeset, field, "has an invalid entry")
+        end
+    end
   end
 end

--- a/test/open_rtb_ecto/v2/bid_request/video_test.exs
+++ b/test/open_rtb_ecto/v2/bid_request/video_test.exs
@@ -1,0 +1,10 @@
+defmodule OpenRtbEcto.V2.BidRequest.VideoTest do
+  use ExUnit.Case, async: true
+  alias OpenRtbEcto.V2.BidRequest.Video
+
+  test "video.api field must contain only positive integers" do
+    assert {:ok, _} = OpenRtbEcto.cast(Video, "{\"api\":[7],\"mimes\":[\"video/mp4\"]}")
+    assert {:error, %{api: errors}} = OpenRtbEcto.cast(Video, "{\"api\":[-7]}")
+    assert ["has an invalid entry, got [-7]"] = errors
+  end
+end

--- a/test/open_rtb_ecto_test.exs
+++ b/test/open_rtb_ecto_test.exs
@@ -21,8 +21,8 @@ defmodule OpenRtbEctoTest do
     end
 
     test "charlists in errors are displayed as lists" do
-      assert {:error, reason} = OpenRtbEcto.cast(Video, "{\"api\":[7]}")
-      assert %{api: ["has an invalid entry, got [7]"]} = reason
+      assert {:error, reason} = OpenRtbEcto.cast(Video, "{\"companiontype\":[4]}")
+      assert %{companiontype: ["has an invalid entry, got [4]"]} = reason
     end
   end
 end


### PR DESCRIPTION
Recently we became aware of the OMID SDK which adds `7` as a valid value
for the video.api field. Before this PR, this value would be considered
invalid, so we have decided to loosen the requirements.