### PR TITLE
Relax SUA validation for malformed bid requests

### DIFF
--- a/lib/open_rtb_ecto/v2/bid_request/brand_version.ex
+++ b/lib/open_rtb_ecto/v2/bid_request/brand_version.ex
@@ -20,7 +20,6 @@ defmodule OpenRtbEcto.V2.BidRequest.BrandVersion do
     version
     |> cast(attrs, [:brand, :version])
     |> OpenRtbEcto.safe_cast_ext(attrs)
-    |> validate_required([:brand])
   end
 
   def changeset(version, _), do: change(version)

--- a/lib/open_rtb_ecto/v2/bid_request/user_agent.ex
+++ b/lib/open_rtb_ecto/v2/bid_request/user_agent.ex
@@ -29,9 +29,17 @@ defmodule OpenRtbEcto.V2.BidRequest.UserAgent do
     user_agent
     |> cast(attrs, [:mobile, :architecture, :bitness, :model, :source])
     |> OpenRtbEcto.safe_cast_ext(attrs)
-    |> cast_embed(:browsers)
+    |> safe_cast_browsers(attrs)
     |> cast_embed(:platform)
   end
 
   def changeset(user_agent, _), do: change(user_agent)
+
+  defp safe_cast_browsers(changeset, %{"browsers" => browsers}) when is_list(browsers),
+    do: cast_embed(changeset, :browsers)
+
+  defp safe_cast_browsers(changeset, %{browsers: browsers}) when is_list(browsers),
+    do: cast_embed(changeset, :browsers)
+
+  defp safe_cast_browsers(changeset, _attrs), do: changeset
 end

--- a/test/open_rtb_ecto/v2/bid_request_test.exs
+++ b/test/open_rtb_ecto/v2/bid_request_test.exs
@@ -134,6 +134,20 @@ defmodule OpenRtbEcto.V2.BidRequestTest do
               }} = OpenRtbEcto.cast(BidRequest, data)
     end
 
+    test "structured user-agent with null browsers and empty brand" do
+      data = TestHelper.test_data("v2/request", "structured-ua.json")
+
+      data =
+        put_in(data, ["device", "sua"], %{
+          "browsers" => nil,
+          "platform" => %{"brand" => ""},
+          "source" => 0
+        })
+
+      assert {:ok, %BidRequest{device: %Device{sua: %UserAgent{browsers: [], source: 0}}}} =
+               OpenRtbEcto.cast(BidRequest, data)
+    end
+
     test "multiple imps" do
       data = TestHelper.test_data("v2/request", "multi-imp.json")
       assert {:ok, %BidRequest{} = req} = OpenRtbEcto.cast(BidRequest, data)


### PR DESCRIPTION
## Summary
- Remove `validate_required([:brand])` from `BrandVersion` — SSPs send SUA with empty or missing brand strings (e.g. `"brand": ""`) which should not invalidate the entire bid request
- Handle `"browsers": null` in `UserAgent` changeset — `cast_embed(:browsers)` raises on null for `embeds_many`, so we now skip the cast when browsers is not a list
- Add test covering the exact real-world scenario (null browsers + empty platform brand)

## Test plan
- [x] All 33 existing tests pass
- [x] New test validates parsing of SUA with `"browsers": null` and `"platform": {"brand": ""}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/appmonet/open_rtb_ecto/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small changes to Ecto changesets to tolerate malformed SUA input; low risk but could reduce validation strictness for `brand` and skip browser casting when the payload is not a list.
> 
> **Overview**
> Relaxes V2 structured user-agent handling so malformed client-hint payloads don’t invalidate the whole bid request.
> 
> Specifically, `BrandVersion` no longer requires `brand`, and `UserAgent` now only `cast_embed(:browsers)` when the incoming `browsers` value is a list (skipping `null`/non-list values). Adds a regression test that ensures casting succeeds with `"browsers": null` and an empty platform `brand`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2f5d53d5acf084403648d9c0f14273827c25ac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed SUA validation so malformed fields no longer invalidate entire bid requests. Empty/missing platform brand and null browsers are now tolerated.

- **Bug Fixes**
  - Removed required check for platform brand in BrandVersion; empty or missing brand is accepted.
  - UserAgent safely skips casting browsers unless it’s a list; null input leaves browsers as [].
  - Added a test covering null browsers with an empty platform brand.

<sup>Written for commit a2f5d53d5acf084403648d9c0f14273827c25ac3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

